### PR TITLE
Tech 9395 update to use newer redis gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ build/
 /_yardoc/
 /doc/
 /rdoc/
+/.idea/
 
 ## Environment normalization:
 /.bundle/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,50 @@
+PATH
+  remote: .
+  specs:
+    redis_cluster (0.3.1)
+      hiredis (~> 0.6)
+      redis (~> 4.5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (11.1.3)
+    coderay (1.1.3)
+    diff-lcs (1.5.0)
+    hiredis (0.6.3)
+    method_source (1.0.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    rake (10.5.0)
+    redis (4.8.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.0)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.11)
+  pry
+  pry-byebug
+  rake (~> 10.0)
+  redis_cluster!
+  rspec (~> 3.0)
+
+BUNDLED WITH
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis_cluster (0.3.1)
+    redis_cluster (0.3.3.pre.1)
       hiredis (~> 0.6)
       redis (~> 4.5)
 

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,3 +1,3 @@
 module RedisCluster
-  VERSION = "0.3.3-pre1"
+  VERSION = "0.3.3-1"
 end

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,3 +1,3 @@
 module RedisCluster
-  VERSION = "0.3.1"
+  VERSION = "0.3.3-pre1"
 end

--- a/redis_cluster.gemspec
+++ b/redis_cluster.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "redis", "~> 3.2"
+  spec.add_dependency "redis", "~> 4.5"
   spec.add_dependency "hiredis", "~> 0.6"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
TECH-9395 updating redis gem version to test web with newer redis, to eventually upgrade sideqik version.