### PR TITLE
Configure gem release host to point to Gemfury

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis_cluster (0.3.2)
+    redis_cluster (0.3.3.tstarck.1)
       hiredis (~> 0.6)
       redis (>= 3.2, <= 4.5.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
     thor (1.2.1)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-19
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis_cluster (0.3.3.tstarck.1)
+    redis_cluster (0.3.3)
       hiredis (~> 0.6)
       redis (>= 3.2, <= 4.5.1)
 
@@ -24,7 +24,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.10)
     rake (13.0.6)
-    redis (3.3.5)
+    redis (4.5.1)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,3 +1,3 @@
 module RedisCluster
-  VERSION = "0.3.2"
+  VERSION = "0.3.3.tstarck.1"
 end

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,3 +1,3 @@
 module RedisCluster
-  VERSION = "0.3.3.tstarck.1"
+  VERSION = "0.3.3"
 end

--- a/redis_cluster.gemspec
+++ b/redis_cluster.gemspec
@@ -16,11 +16,9 @@ Gem::Specification.new do |spec|
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "https://rubygems.org"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
-  end
+  spec.metadata = {
+    'allowed_push_host' => "https://gem.fury.io/invoca"
+  }
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"


### PR DESCRIPTION
Point the `allowed_push_host` to Gemfury instead of rubygems.