### PR TITLE
TECH-13017 RedisCluster: refresh the host addresses automatically when necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# CHANGELOG for `redis_cluster`
+
+Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.3.4] - 2023-10-24
+### Changed
+- Added error handling to refresh IP addresses when a `CannotConnectError` exception is encountered.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis_cluster (0.3.3)
+    redis_cluster (0.3.4.pre.0)
       hiredis (~> 0.6)
       redis (>= 3.2, <= 4.5.1)
 
@@ -54,4 +54,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.3.10
+   2.3.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis_cluster (0.3.4.pre.0)
+    redis_cluster (0.4.0.pre.1)
       hiredis (~> 0.6)
       redis (>= 3.2, <= 4.5.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis_cluster (0.4.0.pre.1)
+    redis_cluster (0.3.4)
       hiredis (~> 0.6)
       redis (>= 3.2, <= 4.5.1)
 

--- a/lib/redis_cluster/client.rb
+++ b/lib/redis_cluster/client.rb
@@ -44,9 +44,9 @@ module RedisCluster
       # The first is for intermittent failures like "host unreachable" or
       # timeouts. These are retried a number of times equal to @retry_count.
       #
-      # The second is when it receives an `ASK` or `MOVED` error response from
+      # The second is when it receives an `ASK`, `MOVED`, or 'Error' error response from
       # Redis. In this case the client will complete re-enter its execution
-      # loop and retry the command after any necessary prework (if `MOVED`, it
+      # loop and retry the command after any necessary prework (if `MOVED` or 'Error', it
       # will attempt to reload the node pool first). This will only ever be
       # retried one time (see notes below). This loop uses Ruby's `retry`
       # syntax for blocks, so keep an eye out for that in the code below.
@@ -64,18 +64,20 @@ module RedisCluster
           # Getting an error while executing may be an indication that we've
           # lost the node that we were talking to and in that case it makes
           # sense to try a different node and maybe reload our node pool (if
-          # the new node issues a `MOVE`).
+          # the new node issues a `MOVE` or a ConnectError).
           try_random_node = attempt > 0
 
           return @pool.execute(method, args, {asking: asking, random_node: try_random_node}, &block)
         end
-      rescue Redis::CommandError => e
+      # rescue Redis::CannotConnectError, Redis::CommandError => e
+      rescue Redis::CommandError, Redis::CannotConnectError => e
+        puts e.inspect
         unless @logger.nil?
           @logger.error("redis_cluster: Received error: #{e}")
         end
 
         # This is a special condition to protect against a misbehaving library
-        # or server. After we've gotten one ASK or MOVED and retried once,
+        # or server. After we've gotten one ASK, MOVED, or Error and retried once,
         # we'll never do so a second time. Receiving two of any operations in a
         # row is probably indicative of a problem and we don't want to get
         # stuck in an infinite retry loop.
@@ -92,9 +94,9 @@ module RedisCluster
           asking = true
           retry
 
-        when 'MOVED'
+        when 'MOVED', 'Error'
           unless @logger.nil?
-            @logger.info("redis_cluster: Received MOVED; retrying operation (#{e})")
+            @logger.info("redis_cluster: Received #{err_code}; retrying operation (#{e})")
           end
 
           # `MOVED` indicates a permanent redirect which means that our slot

--- a/lib/redis_cluster/client.rb
+++ b/lib/redis_cluster/client.rb
@@ -69,9 +69,7 @@ module RedisCluster
 
           return @pool.execute(method, args, {asking: asking, random_node: try_random_node}, &block)
         end
-      # rescue Redis::CannotConnectError, Redis::CommandError => e
       rescue Redis::CommandError, Redis::CannotConnectError => e
-        puts e.inspect
         unless @logger.nil?
           @logger.error("redis_cluster: Received error: #{e}")
         end
@@ -242,14 +240,13 @@ module RedisCluster
     # attempt is raised to the user.
     def retry_intermittent_loop
       last_error = nil
-
       for attempt in 0..(@retry_count) do
         begin
           yield(attempt)
 
           # Fall through on any success.
           return
-        rescue Errno::EACCES, Redis::TimeoutError, Redis::CannotConnectError => e
+        rescue Errno::EACCES, Redis::TimeoutError => e
           last_error = e
 
           unless @logger.nil?

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,3 +1,3 @@
 module RedisCluster
-  VERSION = "0.4.0.pre.1"
+  VERSION = "0.3.4"
 end

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,3 +1,3 @@
 module RedisCluster
-  VERSION = "0.3.4.pre.0"
+  VERSION = "0.4.0.pre.1"
 end

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,3 +1,3 @@
 module RedisCluster
-  VERSION = "0.3.3"
+  VERSION = "0.3.4.pre.0"
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -58,16 +58,27 @@ describe "client" do
       ]
       allow_any_instance_of(Redis).to receive(:cluster).and_return(cluster_nodes)
 
-      redis_7002 = double("7002")
-      allow(redis_7002).to receive(:get).and_raise(Redis::CommandError.new("MOVED 15495 127.0.0.1:7006"))
-      @redis.instance_variable_get("@pool").nodes.find {|node| node.instance_variable_get("@options")[:port] == 7002 }.instance_variable_set("@connection", redis_7002)
+      @redis_7002 = double("7002")
 
       redis_7006 = double("7006")
       allow(redis_7006).to receive(:get).and_return(@value)
       @redis.instance_variable_get("@pool").nodes.find {|node| node.instance_variable_get("@options")[:port] == 7006 }.instance_variable_set("@connection", redis_7006)
     end
 
-    it "redetect nodes and get right redis value" do
+    it "redetect nodes and get right redis value on MOVED response" do
+      allow(@redis_7002).to receive(:get).and_raise(Redis::CommandError.new("MOVED 15495 127.0.0.1:7006"))
+      @redis.instance_variable_get("@pool").nodes.find {|node| node.instance_variable_get("@options")[:port] == 7002 }.instance_variable_set("@connection", @redis_7002)
+
+      expect(@redis.get("a")).to eq @value
+
+      node_7006 = pool_nodes.find {|node| node.instance_variable_get("@options")[:port] == 7006 }
+      expect(node_7006.has_slot? 15495).to be_truthy
+    end
+
+    it "redetect nodes and get right redis value on Error response" do
+      allow(@redis_7002).to receive(:get).and_raise(Redis::CannotConnectError.new("Error connecting to Redis"))
+      @redis.instance_variable_get("@pool").nodes.find {|node| node.instance_variable_get("@options")[:port] == 7002 }.instance_variable_set("@connection", @redis_7002)
+
       expect(@redis.get("a")).to eq @value
 
       node_7006 = pool_nodes.find {|node| node.instance_variable_get("@options")[:port] == 7006 }

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -58,16 +58,15 @@ describe "client" do
       ]
       allow_any_instance_of(Redis).to receive(:cluster).and_return(cluster_nodes)
 
-      @redis_7002 = double("7002")
-
       redis_7006 = double("7006")
       allow(redis_7006).to receive(:get).and_return(@value)
       @redis.instance_variable_get("@pool").nodes.find {|node| node.instance_variable_get("@options")[:port] == 7006 }.instance_variable_set("@connection", redis_7006)
     end
 
     it "redetect nodes and get right redis value on MOVED response" do
-      allow(@redis_7002).to receive(:get).and_raise(Redis::CommandError.new("MOVED 15495 127.0.0.1:7006"))
-      @redis.instance_variable_get("@pool").nodes.find {|node| node.instance_variable_get("@options")[:port] == 7002 }.instance_variable_set("@connection", @redis_7002)
+      redis_7002 = double("7002")
+      allow(redis_7002).to receive(:get).and_raise(Redis::CommandError.new("MOVED 15495 127.0.0.1:7006"))
+      @redis.instance_variable_get("@pool").nodes.find {|node| node.instance_variable_get("@options")[:port] == 7002 }.instance_variable_set("@connection", redis_7002)
 
       expect(@redis.get("a")).to eq @value
 
@@ -76,8 +75,9 @@ describe "client" do
     end
 
     it "redetect nodes and get right redis value on Error response" do
-      allow(@redis_7002).to receive(:get).and_raise(Redis::CannotConnectError.new("Error connecting to Redis"))
-      @redis.instance_variable_get("@pool").nodes.find {|node| node.instance_variable_get("@options")[:port] == 7002 }.instance_variable_set("@connection", @redis_7002)
+      redis_7002 = double("7002")
+      allow(redis_7002).to receive(:get).and_raise(Redis::CannotConnectError.new("Error connecting to Redis"))
+      @redis.instance_variable_get("@pool").nodes.find {|node| node.instance_variable_get("@options")[:port] == 7002 }.instance_variable_set("@connection", redis_7002)
 
       expect(@redis.get("a")).to eq @value
 
@@ -141,7 +141,7 @@ describe "client" do
         redis_double = double("Redis connection")
         allow(redis_double).to receive(:get) do
           num_invocations += 1
-          raise Redis::CannotConnectError if num_invocations == 1
+          raise Redis::TimeoutError if num_invocations == 1
           "b"
         end
         @redis.instance_variable_get("@pool").nodes.


### PR DESCRIPTION
[RedisCluster: refresh the host addresses automatically when necessary](https://invoca.atlassian.net/browse/TECH-13017)
Updating the error handling on `execute` to refresh nodes when a `Redis::CannotConnectError` exception is caught.

Note: I did not find a ChangeLog.  Not sure where to document these changes.