### PR TITLE
Story 17538 ruby 3 kwargs support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.5] - Unreleased
+## [0.3.5] - 2024-02-23
 ### Fixed
 - Fixed a Ruby 3 compatibility bug where keyword args could not be passed through Node#execute.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.5] - Unreleased
+### Fixed
+- Fixed a Ruby 3 compatibility bug where keyword args could not be passed through Node#execute.
+
 ## [0.3.4] - 2023-10-24
 ### Changed
 - Added error handling to refresh IP addresses when a `CannotConnectError` exception is encountered.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis_cluster (0.3.5.pre.dc.0)
+    redis_cluster (0.3.5.pre.dc.1)
       hiredis (~> 0.6)
       redis (>= 3.2, <= 4.5.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   x86_64-darwin-19
+  x86_64-darwin-21
 
 DEPENDENCIES
   appraisal

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis_cluster (0.3.5.pre.dc.1)
+    redis_cluster (0.3.5)
       hiredis (~> 0.6)
       redis (>= 3.2, <= 4.5.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis_cluster (0.3.4)
+    redis_cluster (0.3.5.pre.dc.0)
       hiredis (~> 0.6)
       redis (>= 3.2, <= 4.5.1)
 

--- a/lib/redis_cluster/client.rb
+++ b/lib/redis_cluster/client.rb
@@ -35,7 +35,7 @@ module RedisCluster
       reload_pool_nodes
     end
 
-    def execute(method, args, &block)
+    def execute(method, args, **kwargs, &block)
       asking = false
       retried = false
 
@@ -67,7 +67,7 @@ module RedisCluster
           # the new node issues a `MOVE` or a ConnectError).
           try_random_node = attempt > 0
 
-          return @pool.execute(method, args, {asking: asking, random_node: try_random_node}, &block)
+          return @pool.execute(method, args, {asking: asking, random_node: try_random_node}, **kwargs, &block)
         end
       rescue Redis::CommandError, Redis::CannotConnectError => e
         unless @logger.nil?
@@ -109,13 +109,13 @@ module RedisCluster
     end
 
     Configuration.method_names.each do |method_name|
-      define_method method_name do |*args, &block|
-        execute(method_name, args, &block)
+      define_method method_name do |*args, **kwargs, &block|
+        execute(method_name, args, **kwargs, &block)
       end
     end
 
-    def method_missing(method, *args, &block)
-      execute(method, args, &block)
+    def method_missing(method, *args, **kwargs, &block)
+      execute(method, args, **kwargs, &block)
     end
 
     # Add default argument to keys to match redis client interface

--- a/lib/redis_cluster/node.rb
+++ b/lib/redis_cluster/node.rb
@@ -32,8 +32,8 @@ module RedisCluster
       execute(:asking)
     end
 
-    def execute(...)
-      connection.public_send(...)
+    def execute(method, args, **kwargs, &block)
+      connection.public_send(method, *args, **kwargs, &block)
     end
 
     def connection

--- a/lib/redis_cluster/node.rb
+++ b/lib/redis_cluster/node.rb
@@ -32,8 +32,8 @@ module RedisCluster
       execute(:asking)
     end
 
-    def execute(method, args, &block)
-      connection.public_send(method, *args, &block)
+    def execute(...)
+      connection.public_send(...)
     end
 
     def connection

--- a/lib/redis_cluster/pool.rb
+++ b/lib/redis_cluster/pool.rb
@@ -21,18 +21,18 @@ module RedisCluster
       @nodes.delete_if { |n| !names.include?(n.name) }
     end
 
-    # other_options:
+    # node_options:
     #   asking
     #   random_node
-    def execute(method, args, other_options, &block)
+    def execute(method, args, node_options, **kwargs, &block)
       return send(method, args, &block) if Configuration::SUPPORT_MULTI_NODE_METHODS.include?(method.to_s)
 
       key = key_by_command(method, args)
       raise CommandNotSupportedError.new(method.upcase) if key.nil?
 
-      node = other_options[:random_node] ? random_node : node_by(key)
-      node.asking if other_options[:asking]
-      node.execute(method, args, &block)
+      node = node_options[:random_node] ? random_node : node_by(key)
+      node.asking if node_options[:asking]
+      node.execute(method, args, **kwargs, &block)
     end
 
     def keys(args, &block)

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,3 +1,3 @@
 module RedisCluster
-  VERSION = "0.3.5.pre.dc.1"
+  VERSION = "0.3.5"
 end

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,3 +1,3 @@
 module RedisCluster
-  VERSION = "0.3.5.pre.dc.0"
+  VERSION = "0.3.5.pre.dc.1"
 end

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,3 +1,3 @@
 module RedisCluster
-  VERSION = "0.3.4"
+  VERSION = "0.3.5.pre.dc.0"
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -214,7 +214,7 @@ describe "client" do
 
   describe "keys" do
     it "supports a default argument" do
-      allow(pool).to receive(:execute).with("keys", ["*"], {asking: false, random_node: false}).and_return(["abc", "def"])
+      allow(pool).to receive(:execute).with("keys", ["*"], {asking: false, random_node: false}, any_args).and_return(["abc", "def"])
       result = @redis.keys
       expect(result).to eq(["abc", "def"])
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,12 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require_relative "../lib/redis_cluster"
 #require 'pry'
+
+RSpec.configure do |config|
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+end


### PR DESCRIPTION
[Web build](https://github.com/Invoca/web/pull/23120/files) - One prod regression failure just needs a test change deployed
[PNAPI build](https://github.com/Invoca/PNAPI/pull/1273)

## [0.3.5] - Unreleased
### Fixed
- Fixed a Ruby 3 compatibility bug where keyword args could not be passed through Node#execute.
