### PR TITLE
Backstage catalog-info: add system + set owner: octothorpe

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -29,4 +29,5 @@ spec:
   type: library
   lifecycle: production
   owner: octothorpe
+  system: database-operations
   dependsOn: []

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -28,6 +28,6 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: octothorpe
+  owner: sre-core
   system: database-operations
   dependsOn: []

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -28,6 +28,6 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: sre-core
+  owner: octothorpe
   system: database-operations
   dependsOn: []


### PR DESCRIPTION
Backstage `catalog-info.yaml` maintenance (part of JETS-1359 catalog campaign). No code changes.

**Changes**
- Add `system: database-operations`
- `owner: octothorpe` — **corrected**. An earlier pass in this campaign over-corrected the owner to `sre-core`; this reverts it to `octothorpe`, which was the pre-existing owner.

**Why octothorpe (not SRE-Core)**
`redis_cluster` is a forked Ruby *client* gem (cluster-aware Redis client for ElastiCache), not infra provisioning. It's maintained by Octothorpe/backend-platform (recent commits: dcaddell, ishakun) and is a sibling of `redis_tools` (already `owner: octothorpe`). SRE-Core's repos in this campaign are provisioning/ops (chef, terraform, kube, vault, prometheus, mysql-ops).

**Note — deprecation candidate**
The RedisCloud rollout (PNAPI#1314) removes the need for a client-side cluster router. Recommend archiving this gem once the RedisCloud migration completes.